### PR TITLE
chore: reduce log level in handleDiscover

### DIFF
--- a/svc.go
+++ b/svc.go
@@ -231,7 +231,7 @@ func (rz *RendezvousService) handleDiscover(p peer.ID, m *pb.Message_Discover) *
 		return newDiscoverResponseError(pb.Message_E_INTERNAL_ERROR, "database error")
 	}
 
-	log.Infof("discover query: %s %s -> %d", p, ns, len(regs))
+	log.Debugf("discover query: %s %s -> %d", p, ns, len(regs))
 
 	return newDiscoverResponse(regs, cookie)
 }


### PR DESCRIPTION
This PR changes the log level from INFO to DEBUG, for a log line within `handleDiscover` function, since this function is executed frequently in rendezvous points, and this line ends up adding too much noise when browsing logs
```
example: 

2023-03-13T20:42:19.987-0400    INFO    rendezvous      go-libp2p-rendezvous@v0.4.1/svc.go:234  discover query: 16Uiu2HAmG4jyX7gz2MVHzeczDvHa5owG9H7Liu7RAXS2DHG1r8Hm /waku/2/default-waku/proto -> 1   {"node": "16Uiu2HAmMGhfSTUzKbsjMWxc6T1X4wiTWSF1bEWSLjAukCm7KiHV"}
```